### PR TITLE
Changed Player::Kill() to Player::Hurt(-1, null, "ADMIN")

### DIFF
--- a/AdminTools/Commands/Explode/Explode.cs
+++ b/AdminTools/Commands/Explode/Explode.cs
@@ -50,7 +50,7 @@ namespace AdminTools.Commands.Explode
                         if (Ply.Role == RoleType.Spectator || Ply.Role == RoleType.None)
                             continue;
 
-                        Ply.Kill();
+                        Ply.Hurt(-1, null, "ADMIN");
                         EventHandlers.SpawnGrenadeOnPlayer(Ply, GrenadeType.Frag, 0.1f);
                     }
                     response = "Everyone exploded, Hubert cannot believe you have done this";
@@ -75,7 +75,7 @@ namespace AdminTools.Commands.Explode
                         return false;
                     }
 
-                    Pl.Kill();
+                    Pl.Hurt(-1, null, "ADMIN");
                     EventHandlers.SpawnGrenadeOnPlayer(Pl, GrenadeType.Frag, 0.1f);
                     response = $"Player \"{Pl.Nickname}\" game ended (exploded)";
                     return true;

--- a/AdminTools/Commands/Hp/Hp.cs
+++ b/AdminTools/Commands/Hp/Hp.cs
@@ -47,7 +47,7 @@ namespace AdminTools.Commands.Hp
                     foreach (Player Pl in Player.List)
                     {
                         if (value <= 0)
-                            Pl.Kill();
+                            Pl.Hurt(-1, null, "ADMIN");
                         else
                             Pl.Health = value;
                     }
@@ -69,7 +69,7 @@ namespace AdminTools.Commands.Hp
                     }
 
                     if (val <= 0)
-                        Ply.Kill();
+                        Ply.Hurt(-1, null, "ADMIN");
                     else
                         Ply.Health = val;
                     response = $"Player {Ply.Nickname}'s HP was set to {val}";

--- a/AdminTools/Commands/Kill/Kill.cs
+++ b/AdminTools/Commands/Kill/Kill.cs
@@ -43,7 +43,7 @@ namespace AdminTools.Commands.Kill
                         if (Ply.Role == RoleType.Spectator || Ply.Role == RoleType.None)
                             continue;
 
-                        Ply.Kill();
+                        Ply.Hurt(-1, null, "ADMIN");
                     }
 
                     response = "Everyone has been game ended (killed) now";
@@ -61,7 +61,7 @@ namespace AdminTools.Commands.Kill
                         return false;
                     }
 
-                    Pl.Kill();
+                    Pl.Hurt(-1, null, "ADMIN");
                     response = $"Player {Pl.Nickname} has been game ended (killed) now";
                     return true;
             }

--- a/AdminTools/EventHandlers.cs
+++ b/AdminTools/EventHandlers.cs
@@ -201,7 +201,7 @@ namespace AdminTools
 				{
 					player.IsGodModeEnabled = false;
 					SpawnGrenadeOnPlayer(player, GrenadeType.Frag, 0.05f);
-					player.Kill();
+					player.Hurt(-1, null, "ADMIN");
 				}
 
 				yield return Timing.WaitForOneFrame;


### PR DESCRIPTION
I think `Player::Hurt(-1, null, "ADMIN")` is more suitable for killing players than `Player::Kill()`, because only admins can use commands for killing players.