### PR TITLE
Use referencehub instead of nickname when getting player

### DIFF
--- a/AdminTools/Commands/Dummy/Dummy.cs
+++ b/AdminTools/Commands/Dummy/Dummy.cs
@@ -30,7 +30,7 @@ namespace AdminTools.Commands.Dummy
                 return false;
             }
 
-            Player Sender = Player.Get(((CommandSender)sender).Nickname);
+            Player Sender = Player.Get(((CommandSender)sender).ReferenceHub);
             if (arguments.Count < 1)
             {
                 response = "Usage:\ndummy ((player id / name) or (all / *)) (RoleType) (x value) (y value) (z value)" +

--- a/AdminTools/Commands/Id/ID.cs
+++ b/AdminTools/Commands/Id/ID.cs
@@ -62,7 +62,7 @@ namespace AdminTools.Commands.Id
                 default:
                     Player Pl;
                     if (String.IsNullOrWhiteSpace(arguments.At(0)))
-                        Pl = Player.Get(((CommandSender)sender).Nickname);
+                        Pl = Player.Get(((CommandSender)sender).ReferenceHub);
                     else
                     {
                         Pl = Player.Get(arguments.At(0));

--- a/AdminTools/Commands/SpawnWorkbench/SpawnWorkbench.cs
+++ b/AdminTools/Commands/SpawnWorkbench/SpawnWorkbench.cs
@@ -33,7 +33,7 @@ namespace AdminTools.Commands.SpawnWorkbench
                 return false;
             }
 
-            Player Sender = Player.Get(((CommandSender)sender).Nickname);
+            Player Sender = Player.Get(((CommandSender)sender).ReferenceHub);
             if (arguments.Count < 1)
             {
                 response = "Usage: bench ((player id / name) or (all / *)) (x value) (y value) (z value)" +

--- a/AdminTools/Commands/Tutorial/Tutorial.cs
+++ b/AdminTools/Commands/Tutorial/Tutorial.cs
@@ -38,7 +38,7 @@ namespace AdminTools.Commands.Tutorial
                 case 0:
                 case 1:
                     if (arguments.Count == 0)
-                        Ply = Player.Get(((CommandSender)sender).Nickname);
+                        Ply = Player.Get(((CommandSender)sender).ReferenceHub);
                     else
                     {
                         if (String.IsNullOrWhiteSpace(arguments.At(0)))


### PR DESCRIPTION
Why are you even using the nickname when you have much better info on the player?

Anyway, just think about the funny thing that happens when 2 players with the same nickname join and the one later in the list runs `tut` and the first one is made a tutorial because the nickname is used. Yeah this fixes that.